### PR TITLE
 ENH: Synchronize changes between module widget and home widget

### DIFF
--- a/VirtualReality/Widgets/Resources/StyleSheets/VrWidgetStyle.qss
+++ b/VirtualReality/Widgets/Resources/StyleSheets/VrWidgetStyle.qss
@@ -1,73 +1,50 @@
-QAbstractButton,
-QPushButton {
-    border-style: solid;
-    border-width: 1px;
-    border-radius: 0px;
-    background-color: #FFFFFF;
-    border-color: #3a3a3a;
+QWidget {
+	font: 20px;
+}
+
+QAbstractButton {
     color: #3a3a3a;
-    font-family: Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;
-    font: bold 12pt;
-    font-weight: 400;
+    border-color: #3a3a3a;
+	border-style: solid;
+    border-width: 1px;
+    border-radius: 10px; 
     padding: 4px;
 }
 
-QAbstractButton:pressed,
-QPushButton:pressed {
-    border-style: solid;
-    border-width: 1px;
-    border-radius: 0px;
-    background-color: #D7D7D7;
-    border-color: #3a3a3a;
-    color: #3a3a3a;
-    font-family: Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;
-    font: bold 12pt;
-    font-weight: 400;
-    padding: 4px;
+QAbstractButton:hover {
+	background-color:#ABABAB;
 }
 
-QAbstractButton:checked,
-QPushButton:checked {
-    border-style: solid;
-    border-width: 1px;
-    border-radius: 0px;
-    background-color: #D7D7D7;
-    border-color: #3a3a3a;
-    color: #3a3a3a;
-    font-family: Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;
-    font: bold 12pt;
-    font-weight: 400;
-    padding: 4px;
+QAbstractButton:pressed {
+    background-color: #525252;
+}
+
+QSlider {
+    min-height: 68px;
+    max-height: 68px;
+    background: white;
+}
+
+QSlider::groove:horizontal {
+    border: 1px solid #262626;
+	height: 5px;
+    background: #399aef;
+    margin: 0 12px;
 }
 
 QSlider::handle:horizontal {
-	background-color: white;
-	border: 2px solid black;
-	width: 10px;
-	height: 12px;
+    background: white;
+    border: 2px solid black;
+	border-radius: 10px;
+    width: 23px;
+    height: 100px;
+    margin: -24px -12px;
 }
 
-QLabel {
-    font-family: Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;
-    font: bold 12pt;
-    font-weight: 400;
-    color: #3a3a3a;
-    margin-left: 4px; margin-right: 4px;
+QSlider::handle:horizontal:hover {
+	background: #ABABAB;
 }
 
-QCheckBox,
-QCheckBox:pressed,
-QCheckBox:checked {
-    border-style: none;
-    font: bold 12pt;
-    font-weight: 400;
-    background-color: #FFFFFF;
-    color: #3a3a3a;
-}
-
-ctkSliderWidget {
-    font: bold 12pt;
-    font-weight: 400;
-    background-color: #FFFFFF;
-    color: #3a3a3a;
+QSlider::handle:horizontal:pressed {
+	background: #525252;
 }

--- a/VirtualReality/Widgets/qMRMLVirtualRealityHomeWidget.h
+++ b/VirtualReality/Widgets/qMRMLVirtualRealityHomeWidget.h
@@ -56,6 +56,16 @@ public slots:
   /// Set virtual reality view MRML node
   void setVirtualRealityViewNode(vtkMRMLVirtualRealityViewNode* node);
 
+  void onMotionSensitivityChanged(double);
+  void onFlySpeedChanged(double);
+  void onMagnification001xPressed();
+  void onMagnification01xPressed();
+  void onMagnification1xPressed();
+  void onMagnification10xPressed();
+  void onMagnification100xPressed();
+  //void updateViewFromReferenceViewCamera();
+  //void setMagnificationLock(bool);
+
 protected slots:
   /// Update widgets from the MRML node
   void updateWidgetFromMRML();


### PR DESCRIPTION
These changes make it so that changes in the module widget (viewable in Slicer) are reflected in the home widget (viewable in VR) and vice versa